### PR TITLE
Added SLES 12.1, 12.2, 12.3 and 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ names based on os-release:ID
 │   ├── rhel
 │   │   └── 7
 │   ├── sles
-│   │   └── 12
+│   │   ├── 12
+│   │   ├── 12.1
+│   │   ├── 12.2
+│   │   ├── 12.3
+│   │   └── 15
 │   ├── tinycore
 │   │   ├── 5
 │   │   └── boot2docker

--- a/linux/sles/12.1/etc/SuSE-release
+++ b/linux/sles/12.1/etc/SuSE-release
@@ -1,0 +1,5 @@
+SUSE Linux Enterprise Server 12 (x86_64)
+VERSION = 12
+PATCHLEVEL = 1
+# This file is deprecated and will be removed in a future service pack or release.
+# Please check /etc/os-release for details about this release.

--- a/linux/sles/12.1/etc/os-release
+++ b/linux/sles/12.1/etc/os-release
@@ -1,0 +1,7 @@
+NAME="SLES"
+VERSION="12-SP1"
+VERSION_ID="12.1"
+PRETTY_NAME="SUSE Linux Enterprise Server 12 SP1"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12:sp1"

--- a/linux/sles/12.2/etc/SuSE-release
+++ b/linux/sles/12.2/etc/SuSE-release
@@ -1,0 +1,5 @@
+SUSE Linux Enterprise Server 12 (x86_64)
+VERSION = 12
+PATCHLEVEL = 2
+# This file is deprecated and will be removed in a future service pack or release.
+# Please check /etc/os-release for details about this release.

--- a/linux/sles/12.2/etc/os-release
+++ b/linux/sles/12.2/etc/os-release
@@ -1,0 +1,7 @@
+NAME="SLES"
+VERSION="12-SP2"
+VERSION_ID="12.2"
+PRETTY_NAME="SUSE Linux Enterprise Server 12 SP2"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12:sp2"

--- a/linux/sles/12.3/etc/SuSE-release
+++ b/linux/sles/12.3/etc/SuSE-release
@@ -1,0 +1,5 @@
+SUSE Linux Enterprise Server 12 (x86_64)
+VERSION = 12
+PATCHLEVEL = 3
+# This file is deprecated and will be removed in a future service pack or release.
+# Please check /etc/os-release for details about this release.

--- a/linux/sles/12.3/etc/os-release
+++ b/linux/sles/12.3/etc/os-release
@@ -1,0 +1,7 @@
+NAME="SLES"
+VERSION="12-SP3"
+VERSION_ID="12.3"
+PRETTY_NAME="SUSE Linux Enterprise Server 12 SP3"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12:sp3"

--- a/linux/sles/15/etc/os-release
+++ b/linux/sles/15/etc/os-release
@@ -1,0 +1,7 @@
+NAME="SLES"
+VERSION="15"
+VERSION_ID="15"
+PRETTY_NAME="SUSE Linux Enterprise Server 15"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:15"


### PR DESCRIPTION
In case you wounder why SuSE-release is missing in SLES15:
SuSE-release has been deprecated in SLES12 and is no longer there in SLES15.